### PR TITLE
Add sw-toolbox Fastest strategy

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,10 +2,11 @@
         </div>
     </main>
 
-    <script defer src="bower_components/color-thief/dist/color-thief.min.js"></script>
-    <script defer src="bower_components/each/index.js"></script>
+    <script defer src="/bower_components/color-thief/dist/color-thief.min.js"></script>
+    <script defer src="/bower_components/each/index.js"></script>
     <script defer src="/js/toRGB.js"></script>
     <script defer src="/js/header.js"></script>
     <script defer src="/js/favicon.js"></script>
+    <script defer src="/bower_components/sw-toolbox/companion.js" data-service-worker="/sw.js"></script>
 </body>
 </html>

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
   ],
   "dependencies": {
     "color-thief": "^2.0.1",
-    "each": "devcast/each#^1.0.0"
+    "each": "devcast/each#^1.0.0",
+    "sw-toolbox": "^3.1.1"
   }
 }

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,37 @@
+importScripts('/bower_components/sw-toolbox/sw-toolbox.js');
+
+var VERSION = 4
+
+self.addEventListener('install', function (event) {
+    event.waitUntil(self.skipWaiting())
+});
+
+self.addEventListener('activate', function (event) {
+    event.waitUntil(self.clients.claim())
+});
+
+toolbox.router.get('/(images|js|css|bower_components)/*', toolbox.fastest, {
+    cache: {
+        name: 'blog-assets-' + VERSION,
+        maxEntries: 31
+    }
+});
+
+toolbox.router.get('/:slug?', toolbox.fastest, {
+    cache: {
+        name: 'blog-pages-' + VERSION,
+        maxEntries: 31
+    }
+});
+
+// Google APIs
+// currently not working as expected
+// https://github.com/GoogleChrome/sw-toolbox/issues/125
+toolbox.router.get('/*', toolbox.fastest, {
+    debug: true,
+    origin: 'https://fonts.(googleapis|gstatic).com',
+    cache: {
+        name: 'googleapi-' + VERSION,
+        maxEntries: 31,
+    }
+});


### PR DESCRIPTION
check out sw-toolbox doc about the fastest
https://github.com/GoogleChrome/sw-toolbox/blob/3a3d1eed4534fe7a90c529b7
5365aacdcc1b7c24/doc-pages/api.md#toolboxfastest

I had an issue trying to cache google web fonts, it may be fixed in
near future, an issue was opened in sw-toolbox repo
